### PR TITLE
Support rendering posts from other websites

### DIFF
--- a/_fixtures/post_with_redirect.md
+++ b/_fixtures/post_with_redirect.md
@@ -1,0 +1,5 @@
+---
+title: "Post with redirect"
+date: 2022-01-03
+canonical_url: "http://external.com"
+---

--- a/_includes/article.liquid
+++ b/_includes/article.liquid
@@ -2,9 +2,28 @@
   <header class="card-body">
     <h2 class="h4 card-title">{{ include.title }}</h2>
     <p class="card-text">{{ include.excerpt | strip_html }}</p>
-    <a href="{{ include.url }}" class="card-link d-flex align-items-center">
+    <a
+      href="{% if include.canonical_url contains "http" %}{{ include.canonical_url }}{% else %}{{ include.url }}{% endif %}"
+      class="card-link d-flex align-items-center"
+    >
       Read More
-      <span aria-hidden="true">&raquo;</span>
+      {% if include.canonical_url contains 'http' %}
+        <span class="ms-1 mb-1">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            fill="currentColor"
+            class="bi bi-box-arrow-up-right"
+            viewBox="0 0 16 16"
+          >
+            <path fill-rule="evenodd" d="M8.636 3.5a.5.5 0 0 0-.5-.5H1.5A1.5 1.5 0 0 0 0 4.5v10A1.5 1.5 0 0 0 1.5 16h10a1.5 1.5 0 0 0 1.5-1.5V7.864a.5.5 0 0 0-1 0V14.5a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h6.636a.5.5 0 0 0 .5-.5z"/>
+            <path fill-rule="evenodd" d="M16 .5a.5.5 0 0 0-.5-.5h-5a.5.5 0 0 0 0 1h3.793L6.146 9.146a.5.5 0 1 0 .708.708L15 1.707V5.5a.5.5 0 0 0 1 0v-5z"/>
+          </svg>
+        </span>
+      {% else %}
+        <span aria-hidden="true">&raquo;</span>
+      {% endif %}
     </a>
   </header>
 </article>

--- a/_includes/head.liquid
+++ b/_includes/head.liquid
@@ -23,7 +23,15 @@
   <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#dc3545">
   <meta name="msapplication-TileColor" content="#da532c">
   <meta name="theme-color" content="#ffffff">
-  <link rel="canonical" content="{{ page.url | absolute_url }}">
+  {% if page.canonical_url %}
+    <meta http-equiv="refresh" content="0;url={{ page.canonical_url }}">
+    <link
+      rel="canonical"
+      content="{{ page.canonical_url }}"
+    >
+  {% else %}
+    <link rel="canonical" content="{{ page.url | absolute_url }}">
+  {% endif %}
   <link rel="stylesheet" href="{{ "/assets/css/main.css" | relative_url }}">
   {% if page.type == 'category' %}
     <meta

--- a/_layouts/archive.liquid
+++ b/_layouts/archive.liquid
@@ -17,7 +17,8 @@
               {% capture title %} {{ post.title }} {% endcapture %}
               {% capture excerpt %} {{ post.excerpt }} {% endcapture %}
               {% capture url %} {{ post.url }} {% endcapture %}
-              {% include article.liquid title=title excerpt=excerpt url=url %}
+              {% capture canonical_url %} {{ post.canonical_url }} {% endcapture %}
+              {% include article.liquid title=title excerpt=excerpt url=url canonical_url=canonical_url %}
             {% endfor %}
           </section>
           <aside class="col col-sm-4 vstack gap-4">

--- a/_layouts/blog.liquid
+++ b/_layouts/blog.liquid
@@ -17,7 +17,8 @@
               {% capture title %} {{ post.title }} {% endcapture %}
               {% capture excerpt %} {{ post.excerpt }} {% endcapture %}
               {% capture url %} {{ post.url }} {% endcapture %}
-              {% include article.liquid title=title excerpt=excerpt url=url %}
+              {% capture canonical_url %} {{ post.canonical_url }} {% endcapture %}
+              {% include article.liquid title=title excerpt=excerpt url=url canonical_url=canonical_url %}
             {% endfor %}
           </section>
           <aside class="col col-sm-4 vstack gap-4">

--- a/_layouts/default.liquid
+++ b/_layouts/default.liquid
@@ -9,7 +9,17 @@
         <div class="row mb-4">
           <section class="vstack gap-4 col col-sm-8">
             <div class="card bg-white">
-              <div class="card-body">{{ content }}</div>
+              <div class="card-body">
+                {% if page.canonical_url %}
+                  <p>
+                    You are being redirected to
+                    <a href="{{ page.canonical_url }}">
+                      {{ page.canonical_url }}
+                    </a>
+                  </p>
+                {% endif %}
+                {{ content }}
+              </div>
               {% if page.previous.url or page.next.url %}
                 <div class="card-footer">
                   <nav aria-label="Post navigation">

--- a/_layouts/home.liquid
+++ b/_layouts/home.liquid
@@ -12,11 +12,11 @@
       >
         <h2 id="latest-posts" class="border-bottom border-gray-100">Latest Posts</h2>
         {% for post in site.posts limit: 3 %}
-          {% capture title %} {{ post.title
-        }} {% endcapture %}
+          {% capture title %} {{ post.title }} {% endcapture %}
           {% capture excerpt %} {{ post.excerpt }} {% endcapture %}
           {% capture url %} {{ post.url }} {% endcapture %}
-          {% include article.liquid title=title excerpt=excerpt url=url %}
+          {% capture canonical_url %} {{ post.canonical_url }} {% endcapture %}
+          {% include article.liquid title=title excerpt=excerpt url=url canonical_url=canonical_url %}
         {% endfor %}
         <a href="/blog" class="text-center"
           >View All Posts

--- a/test/personal_site_test.rb
+++ b/test/personal_site_test.rb
@@ -313,6 +313,18 @@ class SystemTest < SystemTestCase
         assert_selector "a[href='#headline-2'][aria-label='Headline 2']"
       end
     end
+
+    def test_post_redirect
+      visit_post "post_with_redirect"
+      canonical_url = page.find("link[rel='canonical']", visible: false)[:content]
+
+      assert_selector "meta[http-equiv='refresh'][content='0;url=http://external.com']", visible: false
+      assert_equal "http://external.com", canonical_url
+      within("main") do
+        assert_text "You are being redirected"
+        assert_selector "a[href='http://external.com']"
+      end
+    end
   end
 
   class ArchiveTest < SystemTest


### PR DESCRIPTION
This allows me to share other posts I've written (like for [thoughtbot]) while ensuring the canonical source gets the credit.

I deliberately render the posts so that the RSS feed and sitemap are updated, but ensure to redirect to the canonical source using the [http-equiv] attribute, or by linking to the canonical post from the index.

One drawback to this approach is that there could be a future case for wanting to control the canonical URL **without** wanting to force a redirect.

Closes #16 

[thoughtbot]: https://thoughtbot.com/blog/authors/steve-polito
[http-equiv]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#examples