### PR TITLE
Suppress warnings when running test suite

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
 require "minitest/test_task"
 
-Minitest::TestTask.create
+Minitest::TestTask.create do |test|
+  test.warning = false
+end


### PR DESCRIPTION
I'm not sure if this is best practice or not, but I was getting a lot of warnings when running the test suite via `bundle exec rake`.

```text
/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/gems/3.1.0/gems/axe-core-api-4.5.1/lib/loader.rb:2: warning: /opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/gems/3.1.0/gems/axe-core-api-4.5.1/lib/loader.rb:2: warning: loading in progress, circular require considered harmful - /opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/gems/3.1.0/gems/axe-core-api-4.5.1/lib/axe/core.rb
5
    from -e:1:in  `<main>'
6
    from -e:1:in  `require'
7
    from /home/runner/work/personal_website/personal_website/test/personal_site_test.rb:1:in  `<top (required)>'
8
    from /home/runner/work/personal_website/personal_website/test/personal_site_test.rb:1:in  `require'
9
    from /home/runner/work/personal_website/personal_website/test/test_helper.rb:6:in  `<top (required)>'
10
    from /home/runner/work/personal_website/personal_website/test/test_helper.rb:6:in  `require'
11
    from /opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/gems/3.1.0/gems/axe-core-api-4.5.1/lib/axe/matchers/be_axe_clean.rb:4:in  `<top (required)>'
12
    from /opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/gems/3.1.0/gems/axe-core-api-4.5.1/lib/axe/matchers/be_axe_clean.rb:4:in  `require_relative'
13
    from /opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/gems/3.1.0/gems/axe-core-api-4.5.1/lib/axe/core.rb:4:in  `<top (required)>'
14
    from /opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/gems/3.1.0/gems/axe-core-api-4.5.1/lib/axe/core.rb:4:in  `require_relative'
15
    from /opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/gems/3.1.0/gems/axe-core-api-4.5.1/lib/loader.rb:2:in  `<top (required)>'
16
    from /opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/gems/3.1.0/gems/axe-core-api-4.5.1/lib/loader.rb:2:in  `require_relative'
```

Since the warnings stemmed from Gems, I wasn't sure if I could really do anything about it 🤷