### PR TITLE
Add content from thoughtbot posts

### DIFF
--- a/_posts/2022-01-06-hotwire-asynchronously-loaded-tooltips.md
+++ b/_posts/2022-01-06-hotwire-asynchronously-loaded-tooltips.md
@@ -7,3 +7,206 @@ categories: ["Ruby on Rails"]
 tags: ["Hotwire"]
 canonical_url: https://thoughtbot.com/blog/hotwire-asynchronously-loaded-tooltips
 ---
+
+Let's build a common yet often overlooked feature: Tooltips. The goal here is to load and display a tooltip rendering a user's avatar and name when hovering over a link.
+
+The code samples contained within omit the majority of the application’s setup. While reading, know that the application’s baseline code was generated with Rails 7 via `rails new`. The rest of the source code from this article can be found [on GitHub][].
+
+[on GitHub]: https://github.com/thoughtbot/hotwire-example-template/tree/hotwire-example-tooltip-fetch
+
+## Setup
+
+Although there are numerous ways in which we can load content asynchronously, we will be leveraging [Turbo][] in this exercise. Turbo is part of the [Hotwire][] ecosystem and is best described as a tool that "bundles several techniques for creating fast, modern, progressively enhanced web applications without using much JavaScript.". Specifically, we'll be utilizing [frames][] which allow us to asynchronously render the contents of individual elements.
+
+```ruby
+# config/routes.rb
+Rails.application.routes.draw do
+  resources :users do
+    resource :tooltip, only: :show
+  end
+end
+```
+
+```ruby
+# app/controllers/tooltips_controller.rb
+class TooltipsController < ApplicationController
+  def show
+    @user = User.find params[:user_id]
+  end
+end
+```
+
+Our setup creates a `/users/:id/tooltip?turbo_frame=tooltip_user_:id` endpoint that will return the markup in `app/views/tooltips/show.html.erb`. We wrap the content in a `<turbo-frame>` with a unique ID so that Turbo will return this particular frame's content when a request with a matching ID is made to this endpoint.
+
+```html
+<!-- app/views/tooltips/show.html.erb -->
+<turbo-frame id="<%= params.fetch :turbo_frame, dom_id(@user) %>" target="_top">
+  <div class="relative">
+    <div class="flex gap-2 items-center p-1 bg-black rounded-md text-white">
+      <%= render partial: "users/user", object: @user, formats: :svg %>
+      <strong>Name:</strong>
+      <%= link_to @user.name, @user, class: "text-white" %>
+    </div>
+    <div
+      class="h-2 w-2 bg-black rotate-45 -top-1 -left-2 ml-[50%] relative"
+    ></div>
+  </div>
+</turbo-frame>
+```
+
+We're deliberately prefixing the ID of the `<turbo-frame>` with `tooltip_user_` (which is coming from the `?turbo_frame=tooltip_user_:id` param) because we will be adding other elements that have an ID generated with the [dom_id][] method. Adding the prefix helps keep the ID unique.
+
+We pass `"_top"` to the `target` attribute to ensure any links clicked within the tooltip will [replace the whole page][], and not just the content within this `<turbo-frame>`.
+
+[Turbo]: https://turbo.hotwired.dev/
+[Hotwire]: https://hotwired.dev/
+[frames]: https://turbo.hotwired.dev/reference/frames
+[dom_id]: https://api.rubyonrails.org/classes/ActionView/RecordIdentifier.html#method-i-dom_id
+[replace the whole page]: https://turbo.hotwired.dev/reference/frames#frame-targeting-the-whole-page-by-default
+
+## Loading the Tooltip
+
+Now that we've created our tooltip endpoint and partial we just need to load them onto the page. This can be achieved with a `<turbo-frame>`.
+
+```html
+<!-- app/views/users/_user.html.erb -->
+<div id="<%= dom_id user %>" class="scaffold_record">
+  <p>
+    <strong>Name:</strong>
+    <%= user.name %>
+  </p>
+
+  <p class="relative">
+    <%= link_to "Show this user", user, class: "peer", aria: { describedby:
+    dom_id(user, :tooltip) } %>
+    <!-- 
+      Right now we're hiding each frame and its children
+      with the `hidden` class. We're revealing each frame
+      and its children with the `peer-hover:block` class.
+     -->
+    <turbo-frame
+      id="<%= dom_id user, :tooltip %>"
+      target="_top"
+      role="tooltip"
+      src="<%= user_tooltip_path(user, turbo_frame: dom_id(user, :tooltip)) %>"
+      class="hidden absolute translate-y-[-150%] z-10
+                        peer-hover:block peer-focus:block hover:block focus-within:block"
+    >
+      <!-- The tooltip will be added here. -->
+    </turbo-frame>
+  </p>
+</div>
+```
+
+Again, we give each `<turbo-frame>` a unique ID by passing in `:tooltip` as the second argument to `dom_id`. We're doing this because we're already calling `dom_id` in this partial as well as in `app/views/tooltips/show.html.erb`.
+
+We set the `src` of the `<turbo-frame>` to the tooltip endpoint we created in the setup. This means that when the page loads, each of these frames will fire off a network request to the tooltip endpoint and render the content of the tooltip in the `<turbo-frame>`.
+
+Just like before, we pass `"_top"` to the `target` attribute to ensure that any links clicked within the tooltip will replace the whole page and not just content of the `<turbo-frame>` that was clicked.
+
+Note that we assign the link an [aria-describedby][] attribute and give the `<turbo-frame>` a `role` of `"tooltip"` to comply with the [ARIA WAI specification for tooltips], which is currently a work in progress.
+
+If you navigate to <http://localhost:3000/users> you may not notice anything special since the tooltips show up when you hover over each link. However a separate network request is made to the tooltip endpoint for each user regardless of whether or not you hover over their link.
+
+![Multiple network requests as seen in the dev tools.](https://images.thoughtbot.com/blog-vellum-image-uploads/SS91GhEdQhm83wPXQ7fl_hw-1.png)
+
+## Loading the Tooltip Asynchronously
+
+Fortunately, optimizing these requests is really easy. All we need to do is add a `loading` attribute and have it set to `"lazy"` to [lazy-load][] the tooltips.
+
+This means the request to the tooltip endpoint will be made only when the `<turbo-frame>` becomes visible in the viewport. This is because `loading="lazy"` is using the [Intersection Observer API][] [under the hood][].
+
+```diff
+ <!-- app/views/users/_user.html.erb -->
+ <div id="<%= dom_id user %>" class="scaffold_record">
+   <p>
+     <strong>Name:</strong>
+     <%= user.name %>
+   </p>
+
+   <p class="relative">
+     <%= link_to "Show this user", user, class: "peer", aria: { describedby: dom_id(user, :tooltip) } %>
+     <!--
+       Right now we're hiding each frame and its children
+       with the `hidden` class. We're revealing each frame
+       and its children with the `peer-hover:block` class.
+      -->
+     <turbo-frame id="<%= dom_id user, :tooltip %>" target="_top" role="tooltip"
+                  src="<%= user_tooltip_path(user, turbo_frame: dom_id(user, :tooltip)) %>"
+                  class="hidden absolute translate-y-[-150%] z-10
+                         peer-hover:block peer-focus:block hover:block focus-within:block"
++                 loading="lazy"
+     >
+       <!-- The tooltip will be added here. -->
+     </turbo-frame>
+   </p>
+ </div>
+```
+
+If you go back to `http://localhost:3000/users` you'll notice that a network request is only made once you hover over the link.
+
+![Hovering over each link loads the tooltip asynchronously](https://images.thoughtbot.com/blog-vellum-image-uploads/rVXa8PJ9Sq2u3G3WXTEZ_hw-2.gif)
+
+Right now we're hiding each frame with the `hidden` class and then revealing it with the `peer-hover:block` class. Both of these classes are provided to us by [Tailwind][] and are a nice abstraction of the [general sibling combinator][]. Even though a `<turbo-frame>` may be in the viewport, the fact that it's not visible prevents the network request from being made. It's only when the `<turbo-frame>` is revealed via CSS that the request is made.
+
+![The Tailwind classes used to abstract the general sibling combinator and reveal the tooltip](https://images.thoughtbot.com/blog-vellum-image-uploads/n8yQbPEhSrClaUTcZ1ve_hw-3.png)
+
+In order to test this, try removing the `hidden` class from the `<turbo-frame>`. You'll notice the tooltips are still lazy-loaded, except this time they are loaded once they come into the viewport.
+
+```diff
+ <!-- app/views/users/_user.html.erb -->
+ <div id="<%= dom_id user %>" class="scaffold_record">
+   <p>
+     <strong>Name:</strong>
+     <%= user.name %>
+   </p>
+
+   <p class="relative">
+     <%= link_to "Show this user", user, class: "peer", aria: { describedby: dom_id(user, :tooltip) } %>
+     <!--
+       Right now we're hiding each frame and its children
+       with the `hidden` class. We're revealing each frame
+       and its children with the `peer-hover:block` class.
+      -->
+     <turbo-frame id="<%= dom_id user, :tooltip %>" target="_top" role="tooltip"
+                  src="<%= user_tooltip_path(user, turbo_frame: dom_id(user, :tooltip)) %>"
+-                 class="hidden absolute translate-y-[-150%] z-10
++                 class="absolute translate-y-[-150%] z-10
+                         peer-hover:block peer-focus:block hover:block focus-within:block"
+                  loading="lazy"
+     >
+       <!-- The tooltip will be added here. -->
+     </turbo-frame>
+   </p>
+ </div>
+```
+
+![Displaying the frame will load the tooltip once it's in the viewport.](https://images.thoughtbot.com/blog-vellum-image-uploads/dQLMVeagQjuj15wOIuAd_hw-4.gif)
+
+[lazy-load]: https://turbo.hotwired.dev/reference/frames#lazy-loaded-frame
+[Tailwind]: https://tailwindcss.com/
+[general sibling combinator]: https://developer.mozilla.org/en-US/docs/Web/CSS/General_sibling_combinator
+[Intersection Observer API]: https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API
+[under the hood]: https://github.com/hotwired/turbo/blob/8bce5f17cd697716600d3b34836365ebcdc04b3f/src/observers/appearance_observer.ts
+[aria-describedby]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby
+[ARIA WAI specification for tooltips]: https://www.w3.org/TR/wai-aria-practices-1.1/#tooltip
+
+## Takeaways
+
+There are two main takeaways from this simple demonstration that extend beyond Hotwire and Tailwind.
+
+### Lazy-load content when you can
+
+There's a cost to each network request, and not all users will be viewing your application on the latest hardware or on a stable internet connection. Consider lazy-loading content that's not critical to the initial page load, especially if that content is not in the viewport.
+
+Turbo makes this easy with its `loading` attribute, but this is not a Turbo specific concept.
+
+### CSS can be leveraged to drive interactions
+
+In our example we're able to reveal the tooltip by hovering over the tooltip's sibling. This may seem like the result of some magical property provided by Tailwind via the [peer class][], but in reality it's just the result of the [general sibling combinator][] (which has been around since Internet Explorer 7) in combination with [user action pseudo-classes][]. This is an incredibly powerful yet under utilized feature of CSS, and is often unnecessarily replicated with JavaScript.
+
+Tailwind has exposed some of the most powerful features that CSS has to offer, but remember that they're just abstractions around existing CSS specifications.
+
+[peer class]: https://tailwindcss.com/docs/hover-focus-and-other-states#styling-based-on-sibling-state
+[general sibling combinator]: https://developer.mozilla.org/en-US/docs/Web/CSS/General_sibling_combinator
+[user action pseudo-classes]: https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes#user_action_pseudo-classes

--- a/_posts/2022-03-28-rails-server-side-analytics-from-scratch.md
+++ b/_posts/2022-03-28-rails-server-side-analytics-from-scratch.md
@@ -7,3 +7,759 @@ categories: ["Ruby on Rails"]
 tags: ["Analytics"]
 canonical_url: https://thoughtbot.com/blog/rails-server-side-analytics-from-scratch
 ---
+
+In this tutorial, we'll learn how to create server-side analytics from scratch using Ruby on Rails. If at any point you wish to explore on your own, simply clone or fork the [example repository](https://github.com/thoughtbot/rails-server-side-analytics) on which this post is based.
+
+## Benefits and Risks
+
+It's important to understand the benefits and risks before implementing your own server-side analytics. Below are a few examples of each.
+
+This tutorial will address all privacy related risks.
+
+### Benefits
+
+- Better performance when compared to client-side tracking via JavaScript.
+- Can't be blocked by an [ad blocker](https://ublockorigin.com/).
+- You have complete control and ownership of your data, and are not giving it to a third party.
+- The code can abstracted into a gem, and reused across multiple applications.
+
+### Risks
+
+- You are responsible for keeping your user's data secure.
+- How long should you keep your user's data?
+- What happens to a user's data if they cancel their account?
+- Should you be tracking a user without their consent?
+
+## Create visitor and track their events
+
+### Create visitor and event models
+
+```ruby
+# db/migrate/[timestamp]_create_visitors.rb
+class CreateVisitors < ActiveRecord::Migration[7.0]
+  def change
+    create_table :visitors do |t|
+      t.string :user_agent
+
+      t.timestamps
+    end
+  end
+end
+```
+
+The `user_agent` column will store data about the user's device and browser. This value will be returned from the [request object](https://api.rubyonrails.org/v7.0.2.2/classes/ActionDispatch/Request.html).
+
+```ruby
+# db/migrate/[timestamp]_create_events.rb
+class CreateEvents < ActiveRecord::Migration[7.0]
+  def change
+    create_table :events do |t|
+      t.string :path, null: false
+      t.string :method, null: false
+      t.string :params
+      t.references :visitor, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end
+```
+
+The `path` column will store the relative path that was requested, while the `method` column will store the type of request made. This will help us determine if someone visited a page as opposed to filled out a form. Finally, the `params` column will store the value of any [query_parameters](https://api.rubyonrails.org/v7.0.2.2/classes/ActionDispatch/Request.html#method-i-query_parameters) or [request_parameters](https://api.rubyonrails.org/v7.0.2.2/classes/ActionDispatch/Request.html#method-i-request_parameters) Again, all of these values will be returned from the [request object](https://api.rubyonrails.org/v7.0.2.2/classes/ActionDispatch/Request.html).
+
+```ruby
+# app/models/visitor.rb
+class Visitor < ApplicationRecord
+  has_many :events
+end
+```
+
+```ruby
+# app/models/event.rb
+class Event < ApplicationRecord
+  serialize :params
+  belongs_to :visitor
+end
+```
+
+The value of `params` will be a `Hash` since we're getting that value from `request.query_parameters` or `request.request_parameters`. Calling [serialize](https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Serialization/ClassMethods.html#method-i-serialize) will ensure the value of `params` is saved to the database as a serialized object, and also retrieved by deserializing into the same object.
+
+### Create a new visitor record each time an anonymous user visits your site
+
+```ruby
+# app/models/current.rb
+class Current < ActiveSupport::CurrentAttributes
+  attribute :visitor
+end
+```
+
+The `Current` model is non-database backed, and inherits from [ActiveSupport::CurrentAttributes](https://api.rubyonrails.org/classes/ActiveSupport/CurrentAttributes.html) which keeps all the per-request attributes easily available to the whole system. This will store the current visitor between requests.
+
+```ruby
+# app/controllers/concerns/set_current_visitor.rb
+module SetCurrentVisitor
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :set_current_visitor
+  end
+
+  private
+
+  def set_current_visitor
+    Current.visitor ||= Visitor.find_by(id: session[:visitor_id]) || create_current_visitor
+  end
+
+  def create_current_visitor
+    visitor = Visitor.create!(
+      user_agent: request.user_agent
+    )
+    session[:visitor_id] = visitor.id
+
+    visitor
+  end
+
+end
+```
+
+The `SetCurrentVisitor` module is an [ActiveSupport::Concern](https://api.rubyonrails.org/classes/ActiveSupport/Concern.html) that stores the logic for setting the current visitor. If the [session](https://guides.rubyonrails.org/action_controller_overview.html#session) contains a value for `visitor_id` that matches an existing `Visitor#id` then that record will be returned. Otherwise, a new visitor record will be created and saved in the `session`.
+
+The `user_agent` is set to the value returned from the `request.user_agent` that is stored in the [request.headers](https://api.rubyonrails.org/classes/ActionDispatch/Request.html#method-i-headers). This value is used to tell what type of device and browser the visitor is using. This information can also be used to detect bots, which could affect data.
+
+```ruby
+# app/controllers/application_controller.rb
+class ApplicationController < ActionController::Base
+  include SetCurrentVisitor
+end
+```
+
+Including the `SetCurrentVisitor` module in the `ApplicationController` ensures the visitor is tracked on all requests.
+
+### Track the visitor's events
+
+```ruby
+# app/controllers/concerns/track_event.rb
+module TrackEvent
+  extend ActiveSupport::Concern
+
+  def track_event
+    Current.visitor.events.create(
+      path: request.path,
+      method: request.method,
+      params: event_params
+    )
+  end
+
+  private
+
+  def event_params
+    request.query_parameters.presence || request.request_parameters.presence
+  end
+end
+```
+
+The `TrackEvent` module is an [ActiveSupport::Concern](https://api.rubyonrails.org/classes/ActiveSupport/Concern.html) that stores the logic for tracking a visitor's events. The `track_event` method simply takes the `path` and `method` returned from the [request](https://api.rubyonrails.org/classes/ActionDispatch/Request.html) and stores it on an `event` record that is associated with the current `visitor`. The private `event_params` method returns the value of [query_parameters](https://api.rubyonrails.org/classes/ActionDispatch/Request.html#method-i-query_parameters) or [request_parameters](https://api.rubyonrails.org/classes/ActionDispatch/Request.html#method-i-request_parameters). Calling [presence](https://api.rubyonrails.org/classes/Object.html#method-i-presence) ensures the logical OR operator will work correctly.
+
+The way in which the `TrackEvent` module is included will affect when and how `event` records are tracked.
+
+Including the `TrackEvent` module in a Controller allows you to call the `track_event` method on specific actions. This is the least comprehensive approach, but also the most performant.
+
+```ruby
+# app/controllers/some_controller.rb
+class SomeController < ApplicationController
+  include TrackEvent
+
+  def some_action
+    track_event
+  end
+end
+```
+
+However, you could also use a [filter](https://guides.rubyonrails.org/action_controller_overview.html#filters) to call the `track_event` method on multiple actions.
+
+```ruby
+# app/controllers/some_controller.rb
+class SomeController < ApplicationController
+  include TrackEvent
+
+  before_action :track_event
+end
+```
+
+Finally, you could include the `TrackEvent` module in the `ApplicationController` and use a [filter](https://guides.rubyonrails.org/action_controller_overview.html#filters) to call the `track_event` method on all controller actions. This would allow you to track every event that every visitor makes.
+
+```ruby
+# app/controllers/application_controller.rb
+class ApplicationController < ActionController::Base
+  include SetCurrentVisitor
+  include TrackEvent
+
+  before_action :track_event
+end
+```
+
+This is the most comprehensive approach, but also the least performant. The risk with this approach is that an additional database call is made at the beginning of **every request for every visitor**. This could result in degraded performance across the entire application.
+
+In all cases, the `track_event` method will return the newly created `event` object, but that return value is ignored. The goal is for the application to always execute each controller action even if the `track_event` method fails to create a new record.
+
+## Filter sensitive data from event records
+
+Extra care needs to be taken since we're saving the value of [request_parameters](https://api.rubyonrails.org/classes/ActionDispatch/Request.html#method-i-request_parameters) into our `events`. Although [Rails automatically filters sensitive data from the logs](https://guides.rubyonrails.org/configuring.html#config-filter-parameters), it does not automatically filter sensitive data from being saved into the database.
+
+This could be a problem if event records are created on sign up.
+
+```ruby
+class UserController < ApplicationController
+  include TrackEvent
+
+  def create
+    track_event
+
+    @user = User.create(user_params)
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:email, :password)
+  end
+
+def
+```
+
+```ruby
+Event.last.params
+# => { user: { email: "user@example.com", password: "MyS3ktretPassword!" } }
+```
+
+Since `track_event` is being called on the `create` action, the values from the sign-up form will be saved to the event because they will be present in the [request_parameters](https://api.rubyonrails.org/classes/ActionDispatch/Request.html#method-i-request_parameters). Even though Rails filters the `password` parameter by default, this doesn't include when that value is saved to the database.
+
+### Update TrackEvent module
+
+```diff
+--- a/app/controllers/concerns/track_event.rb
++++ b/app/controllers/concerns/track_event.rb
+@@ -5,12 +5,20 @@ module TrackEvent
+     Current.visitor.events.create(
+       path: request.path,
+       method: request.method,
+-      params: event_params
++      params: filter_sensitive_data(event_params)
+     )
+   end
+
+   private
+
++  def filter_sensitive_data(params)
++    return if params.nil?
++
++    ActiveSupport::ParameterFilter.new(
++      Rails.application.config.filter_parameters
++    ).filter(params)
++  end
++
+   def event_params
+     request.query_parameters.presence || request.request_parameters.presence
+   end
+```
+
+The method responsible for setting the value of the `params` before saving it to an `event` can be refactored to filter out sensitive values. All that needs to be done is instantiate a new instance of [ActiveSupport::ParameterFilter](https://api.rubyonrails.org/classes/ActiveSupport/ParameterFilter.html) and pass it a hash of parameters to filter. Fortunately, that `hash` already exists in the form of [filtered_parameters](https://api.rubyonrails.org/classes/ActionDispatch/Http/FilterParameters.html#method-i-filtered_parameters). From there, calling [filter](https://api.rubyonrails.org/classes/ActiveSupport/ParameterFilter.html#method-i-filter) against the incoming parameters will ensure the output is filtered.
+
+Now the `params` will be filtered before being saved on an `event` record.
+
+```ruby
+Event.last.params
+# => { user: { email: "user@example.com", password: "[FILTERED]" } }
+```
+
+Rails ships with a set of defaults, but you can always modify this list by updating the `filter_parameter_logging` initializer.
+
+```diff
+--- a/config/initializers/filter_parameter_logging.rb
++++ b/config/initializers/filter_parameter_logging.rb
+@@ -4,5 +4,5 @@
+ # sensitive information. See the ActiveSupport::ParameterFilter documentation for supported
+ # notations and behaviors.
+ Rails.application.config.filter_parameters += [
+-  :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn
++  :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :credit_
+ ]
+```
+
+## Create event records in the background
+
+It's possible to call `track_event` before every single request, which allows for every event a visitor makes to be tracked. This is the most comprehensive approach, but is also the least performant.
+
+```ruby
+# app/controllers/application_controller.rb
+class ApplicationController < ActionController::Base
+  include SetCurrentVisitor
+  include TrackEvent
+
+  before_action :track_event
+end
+```
+
+Creating a new `event` record per each request is a big hit to performance, since an extra request will be made to the database every time a visitor visits a page or fills out a form. Fortunately, this can be solved by leveraging [Active Job](https://guides.rubyonrails.org/active_job_basics.html)
+
+### Create a job to create events in the background
+
+This job simply wraps the logic needed to create an `event` record.
+
+```ruby
+# app/jobs/create_event_job.rb
+class CreateEventJob < ApplicationJob
+  queue_as :default
+
+  def perform(visitor:, path:, method:, params:)
+    visitor.events.create!(
+      path: path,
+      method: method,
+      params: params
+    )
+  end
+end
+```
+
+### Update the track_event method
+
+Modifying the existing `track_event` method ensures all `event` records are created in the background.
+
+Note that the `Current.visitor` is passed into the job, since the job is processed outside the request-cycle.
+
+```diff
+--- a/app/controllers/concerns/track_event.rb
++++ b/app/controllers/concerns/track_event.rb
+@@ -2,7 +2,8 @@ module TrackEvent
+   extend ActiveSupport::Concern
+
+   def track_event
+-    Current.visitor.events.create(
++    CreateEventJob.perform_later(
++      visitor: Current.visitor,
+       path: request.path,
+       method: request.method,
+       params: filter_sensitive_data(event_params)
+```
+
+## Allow a visitor to enable their session to be tracked
+
+A visitor should be given the opportunity to "opt-in" to being tracked in an effort to respect their right to privacy. This is even more important when tracking server-side events, since a visitor's [ad blocker](https://ublockorigin.com/) will not work.
+
+### Create an endpoint to store the visitor's privacy preference
+
+One approach is to store the visitor's preference in the [session](https://guides.rubyonrails.org/action_controller_overview.html#session). This demo assumes an "opt-in" approach, meaning that the visitor will not be tracked until they explicitly enable tracking.
+
+```ruby
+# config/routes.rb
+Rails.application.routes.draw do
+  post "enable_analytics", to: "analytics#enable", as: :enable_analytics
+end
+```
+
+```ruby
+# app/controllers/analytics_controller.rb
+class AnalyticsController < ApplicationController
+  def enable
+    session[:enable_analytics] = true
+
+    redirect_to root_path, notice: "You have enabled your session to be tracked."
+  end
+end
+```
+
+```diff
+--- a/app/views/layouts/application.html.erb
++++ b/app/views/layouts/application.html.erb
+@@ -12,5 +12,8 @@
+
+   <body>
+     <%= yield %>
++    <% unless session[:enable_analytics] == true %>
++      <%= button_to "Enable Analytics", enable_analytics_path %>
++    <% end %>
+   </body>
+ </html>
+```
+
+### Refactor the SetCurrentVisitor and TrackEvent modules to respect the visitor's preference
+
+As soon as a visitor enables tracking, the application will create a `visitor` record and start attaching `event` records to the `visitor`.
+
+```diff
+--- a/app/controllers/concerns/set_current_visitor.rb
++++ b/app/controllers/concerns/set_current_visitor.rb
+@@ -2,7 +2,7 @@ module SetCurrentVisitor
+   extend ActiveSupport::Concern
+
+   included do
+-    before_action :set_current_visitor
++    before_action :set_current_visitor, if: :should_set_current_visitor?
+   end
+
+   private
+@@ -20,4 +20,8 @@ module SetCurrentVisitor
+   def set_current_visitor
+     Current.visitor ||= Visitor.find_by(id: session[:visitor_id]) || create_current_visitor
+   end
++
++  def should_set_current_visitor?
++    session[:enable_analytics] == true
++  end
+ end
+```
+
+```diff
+--- a/app/controllers/concerns/track_event.rb
++++ b/app/controllers/concerns/track_event.rb
+@@ -2,12 +2,14 @@ module TrackEvent
+   extend ActiveSupport::Concern
+
+   def track_event
+-    CreateEventJob.perform_later(
+-      visitor: Current.visitor,
+-      path: request.path,
+-      method: request.method,
+-      params: filter_sensitive_data(event_params)
+-    )
++    if session[:enable_analytics] == true
++      CreateEventJob.perform_later(
++        visitor: Current.visitor,
++        path: request.path,
++        method: request.method,
++        params: filter_sensitive_data(event_params)
++      )
++    end
+   end
+
+   private
+```
+
+## Create methods to return analytics
+
+Tracking events is only valuable if the data can be queried. It's common to want to know how long a visitor is spending on the site, as well as how many times a page has been viewed.
+
+### Query for time on site
+
+Combining [ActiveRecord::QueryMethods](https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html) with [aggregate functions](https://www.postgresql.org/docs/current/functions-aggregate.html) and [date/time functions and operators](https://www.postgresql.org/docs/current/functions-datetime.html) results in a query that returns a two-dimensional `array` where each item returned is a `visitors.id` and the amount of time in seconds that `visitor` spent on the site.
+
+This is calculated by finding the difference between the `created_at` values of the `visitor's` first and last `events`. Because there are no `lower_bounds` or `upper_bounds` columns on the `visitors` table, [pluck](https://api.rubyonrails.org/classes/ActiveRecord/Calculations.html#method-i-pluck) is called, since it returns attribute values. This allows [Arel.sql](https://api.rubyonrails.org/classes/Arel.html#method-c-sql) to be called within `pluck` in order to run the calculation.
+
+```diff
+--- a/app/models/visitor.rb
++++ b/app/models/visitor.rb
+@@ -1,3 +1,21 @@
+ class Visitor < ApplicationRecord
+   has_many :events
++
++  def self.time_on_site
++    select("visitor_id, lower_bounds, upper_bounds")
++      .from(
++        Event
++          .select(
++            "visitor_id,
++            MIN(created_at) AS lower_bounds,
++            MAX(created_at) AS upper_bounds"
++          )
++          .group(:visitor_id)
++      )
++      .pluck(
++        "visitor_id",
++        Arel.sql("EXTRACT(EPOCH FROM (upper_bounds - lower_bounds))")
++      )
++      .sort
++  end
+ end
+```
+
+```ruby
+Visitor.time_on_site
+# => [[3, 0.0], [1, 60.0], [2, 3660.0]]
+```
+
+### Query for page views
+
+Combining [ActiveRecord::QueryMethods](https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html) with [ActiveRecord::Calculations](https://api.rubyonrails.org/classes/ActiveRecord/Calculations.html#method-i-count) results in a query that returns a `hash` where each item returned is the path visited along with how many times that page has been visited. Filtering the results [where](https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-where) the `method` is `GET` ensures results are limited to page views and does not include form submissions.
+
+Using [distinct](https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-distinct) along with [from](https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-from) and [group](https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-group) creates a query that returns unique page views by ignoring multiple page visits from a `visitor`.
+
+```diff
+--- a/app/models/event.rb
++++ b/app/models/event.rb
+@@ -1,4 +1,24 @@
+ class Event < ApplicationRecord
+   serialize :params
+   belongs_to :visitor
++
++  def self.page_views
++    select(:path)
++      .where(method: "GET")
++      .group(:path)
++      .count
++  end
++
++  def self.unique_page_views
++    select(:path)
++      .from(
++        Event
++          .select(:path, :visitor_id)
++          .distinct
++          .where(method: "GET")
++          .group(:path, :visitor_id)
++      )
++      .group(:path)
++      .count(:path)
++  end
+ end
+```
+
+```ruby
+Event.page_views
+# => {"/" => 5, "/search" => 4}
+Event.unique_page_views
+# => {"/" => 3, "/search" => 1}
+```
+
+## Associate data with the current user
+
+Right now, this data is completely anonymous, but it can be helpful to have it associated with an actual user to build a more accurate profile of each user. This comes with additional risks which will be addressed in subsequent sections.
+
+### Associate a visitor with a user
+
+Because a `user` may never sign up or sign in while visiting the site, it's necessary to keep this association [optional](https://guides.rubyonrails.org/association_basics.html#optional). This also means removing `null: false` from the database migration.
+
+```ruby
+# db/migrate/[timestamp]_add_user_id_to_visitors.rb
+class AddUserIdToVisitors < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :visitors, :user, foreign_key: true
+  end
+end
+```
+
+```diff
+--- a/app/models/visitor.rb
++++ b/app/models/visitor.rb
+@@ -1,4 +1,5 @@
+ class Visitor < ApplicationRecord
++  belongs_to :user, optional: true
+   has_many :events
+
+   def self.time_on_site
+```
+
+### Associate the Current.visitor with the current_user
+
+Because every application's authentication system is different, the implementation will vary. All that matters is that the value of the `user` on the `Current.visitor` is set to that of the `current_user`. Because a new `Current.visitor` is created each time the [session](https://guides.rubyonrails.org/action_controller_overview.html#session) resets, this ensures that a `user` will be associated with a new `visit` record each time they sign in to the application.
+
+This is important because it will keep each `visit` and its associated `events` segmented, which is necessary in order to correctly calculate how much time a `user` has spent on the site.
+
+```ruby
+# app/controllers/sessions_controller.rb
+class SessionsController < ApplicationController
+  def create
+    ...
+    Current.visitor.presence && Current.visitor.update!(user: current_user)
+  end
+end
+```
+
+```ruby
+# app/controllers/users_controller.rb
+class UsersController < ApplicationController
+  def create
+    ...
+    Current.visitor.presence && Current.visitor.update!(user: current_user)
+  end
+end
+```
+
+## Create methods to return user analytics
+
+Now that a `visit` is being associated with a `user` it will be helpful to create additional queries to return analytics on `user` accounts.
+
+### Query for time on site per visitor
+
+Creating a separate `time_on_site_for_visitor` [scope](https://api.rubyonrails.org/classes/ActiveRecord/Scoping/Named/ClassMethods.html#method-i-scope) that returns the most recent and oldest `created_at` values per `visitor` allows that query to be chained with [ActiveRecord::Calculations](https://api.rubyonrails.org/classes/ActiveRecord/Calculations.html#method-i-average) methods. This also allows the query to be cleanly reused in the `total_time_on_site_for_visitor` and `average_time_on_site_for_visitor` class methods.
+
+Each class method has access to the virtual `upper_bounds` and `lower_bounds` columns passed in from the `time_on_site_for_visitor` scope. This makes it possible to use those values in [Arel.sql](https://api.rubyonrails.org/classes/Arel.html#method-c-sql).
+
+```diff
+--- a/app/models/visitor.rb
++++ b/app/models/visitor.rb
+@@ -2,6 +2,20 @@ class Visitor < ApplicationRecord
+   belongs_to :user, optional: true
+   has_many :events
+
++  scope :time_on_site_for_visitor, ->(visitor) {
++    select("lower_bounds, upper_bounds")
++      .from(
++        Event
++        .select(
++          "visitor_id,
++          MIN(created_at) AS lower_bounds,
++          MAX(created_at) AS upper_bounds"
++        )
++        .where(visitor: visitor)
++        .group(:visitor_id)
++      )
++  }
++
+   def self.time_on_site
+     select("visitor_id, lower_bounds, upper_bounds")
+       .from(
+@@ -19,4 +33,16 @@ class Visitor < ApplicationRecord
+       )
+       .sort
+   end
++
++  def self.total_time_on_site_for_visitor(visitor)
++    time_on_site_for_visitor(visitor).sum(
++      Arel.sql("EXTRACT(EPOCH FROM (upper_bounds - lower_bounds))")
++    )
++  end
++
++  def self.average_time_on_site_for_visitor(visitor)
++    time_on_site_for_visitor(visitor).average(
++      Arel.sql("EXTRACT(EPOCH FROM (upper_bounds - lower_bounds))")
++    )
++  end
+ end
+```
+
+### Query for time on site per user and associate a user with an event and a visit.
+
+The queries created in the previous step can be easily reused in instance methods on the `user`.
+
+```ruby
+# app/models/user.rb
+class User < ApplicationRecord
+  has_many :visits, class_name: "Visitor"
+  has_many :events, through: :visits
+
+  def time_on_site
+    Visitor.total_time_on_site_for_visitor(visits)
+  end
+
+  def average_time_on_site
+    Visitor.average_time_on_site_for_visitor(visits)
+  end
+end
+```
+
+```ruby
+User.first.time_on_site
+# Time in seconds
+# => 3600
+User.first.average_time_on_site
+# Time in seconds
+# => 2730
+```
+
+Additionally, the use of [has_many](https://api.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html#method-i-has_many) adds the ability to query for `event` and `visit` records on the `user`.
+
+```ruby
+User.first.events
+# The user's entire event history.
+# => [#<Event>, #<Event>]
+User.first.visits
+# Each of the user's visits.
+# => [#<Visitor>, #<Visitor>]
+```
+
+## Provide multiple mechanisms for clearing user history
+
+It's important to provide multiple mechanisms for clearing user history in an effort to reduce risk and keep your user's privacy in mind.
+
+### Update migrations to ensure associated data is deleted automatically
+
+Updating the existing migrations to use a [cascading foreign key](https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-add_foreign_key-label-Creating+a+cascading+foreign+key) ensure that when a `user` is deleted from the database their associated `visitor` and `event` records will be automatically deleted too.
+
+An alternative approach is to use `dependent: :destroy` in the associated models, but this is less performant because it will iterate through each record in order to trigger any callbacks or validations.
+
+```diff
+--- a/db/migrate/[timestamp]_create_events.rb
++++ b/db/migrate/[timestamp]_create_events.rb
+@@ -4,7 +4,7 @@ class CreateEvents < ActiveRecord::Migration[7.0]
+       t.string :path, null: false
+       t.string :method, null: false
+       t.string :params
+-      t.references :visitor, null: false, foreign_key: true
++      t.references :visitor, null: false, foreign_key: {on_delete: :cascade}
+
+       t.timestamps
+     end
+```
+
+```diff
+--- a/db/migrate/[timestamp]_add_user_id_to_visitors.rb
++++ b/db/migrate/[timestamp]_add_user_id_to_visitors.rb
+@@ -1,5 +1,5 @@
+ class AddUserIdToVisitors < ActiveRecord::Migration[7.0]
+   def change
+-    add_reference :visitors, :user, foreign_key: true
++    add_reference :visitors, :user, foreign_key: {on_delete: :cascade}
+   end
+ end
+```
+
+### Create an endpoint allowing a user to clear their history on-demand
+
+It's common to allow a user to be able to clear their history. Adding this endpoint ensures they have a way to do this on-demand.
+
+```diff
+--- a/config/routes.rb
++++ b/config/routes.rb
+@@ -8,4 +8,5 @@ Rails.application.routes.draw do
+   post "sign_up", to: "pages#sign_up", as: :sign_up
+   post "sign_in", to: "pages#sign_in", as: :sign_in
+   post "enable_analytics", to: "analytics#enable", as: :enable_analytics
++  delete "clear_history", to: "analytics#clear_history", as: :clear_history
+ end
+```
+
+```diff
+--- a/app/controllers/analytics_controller.rb
++++ b/app/controllers/analytics_controller.rb
+@@ -4,4 +4,11 @@ class AnalyticsController < ApplicationController
+
+     redirect_to root_path, notice: "You have enabled your session to be tracked."
+   end
++
++  def clear_history
++    current_user.visits.destroy_all
++
++    redirect_to root_path, notice: "History deleted."
++  end
+ end
+```
+
+The updates made to the `foreign_key` option in the existing migrations make it so that calling [destroy_all](https://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-destroy_all) will also delete the user's associated `event` records.
+
+### Create a mechanism to delete history older than a certain date
+
+Adding a mechanism to delete user history that is older than a certain date should be considered in order to reduce risk (and database space).
+
+```diff
+--- a/app/models/visitor.rb
++++ b/app/models/visitor.rb
+@@ -45,4 +45,8 @@ class Visitor < ApplicationRecord
+       Arel.sql("EXTRACT(EPOCH FROM (upper_bounds - lower_bounds))")
+     )
+   end
++
++  def self.delete_all_older_than(timestamp)
++    destroy_by("created_at < ?", timestamp)
++  end
+ end
+```
+
+```ruby
+Visitor.delete_all_older_than(6.months.ago)
+```
+
+Using [destroy_by](https://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-destroy_by) makes this easy. Consider scheduling a recurring [job](https://guides.rubyonrails.org/active_job_basics.html) to call this method.
+
+## Wrapping up
+
+Creating a transparent "opt-in" tracking approach in combination with allowing users to delete their history helps foster trust between you and your user base. This trust is just as valuable as any metrics you'll capture.

--- a/_posts/2022-06-07-query-by-duration-in-active-record.md
+++ b/_posts/2022-06-07-query-by-duration-in-active-record.md
@@ -8,3 +8,133 @@ categories: ["Ruby on Rails"]
 tags: ["PostgreSQL"]
 canonical_url: https://thoughtbot.com/blog/query-by-duration-in-active-record
 ---
+
+In this tutorial, we’ll learn how to query and group records by duration using Active Record. If at any point you wish to explore on your own, simply clone or fork the [example repository](https://github.com/thoughtbot/active-record-recipes) on which this post references.
+
+Let’s get cooking!
+
+## Our domain
+
+Below are the models and their associations we'll be using for this exercise.
+
+```ruby
+class Recipe < ApplicationRecord
+  has_many :steps
+end
+
+class Step < ApplicationRecord
+  belongs_to :recipe
+end
+```
+
+## Store duration as an interval and not an integer
+
+It might be tempting to store the duration as an integer in a **duration_in_seconds** column. However, PostgreSQL provides a better solution to this problem with its [interval](https://www.postgresql.org/docs/14/datatype-datetime.html#DATATYPE-INTERVAL-INPUT) datatype. What's more, [Rails provides an abstraction around this datatype](https://guides.rubyonrails.org/v7.0.3/active_record_postgresql.html#interval) that can be used in migrations.
+
+```ruby
+class CreateSteps < ActiveRecord::Migration[7.0]
+  def change
+    create_table :steps do |t|
+      t.interval :duration
+      ...
+    end
+  end
+end
+```
+
+This is not only semantically correct, but also makes for a cleaner interface. It means we can add records like this:
+
+```ruby
+step = Step.new(duration: 10.minutes)
+step.duration
+# => 10.minutes
+```
+
+## Query for records by their duration
+
+Let’s start simple and query for **steps** by their duration.
+
+```ruby
+Step.where(duration: 10.minutes)
+# => [#<Step>]
+```
+
+This is easy because we can query against the table that has the **duration** without needing to run any calculations.
+
+However, that will just query for all records whose duration is exactly 10 minutes. Passing an [endless range](https://ruby-doc.org/core-3.1.2/Range.html#class-Range-label-Endless+Ranges) will use a comparison operator.
+
+```ruby
+Step.where(duration: ..10.minutes)
+# => [#<Step>, #<Step>]
+```
+
+Note that the use of two dots will result in a less than or equal comparison, while the use of three dots will in a less than comparison.
+
+```ruby
+Step.where(duration: ..10.minutes).to_sql
+# => SELECT "steps".* FROM "steps" WHERE "steps"."duration" <= 'PT10M'
+Step.where(duration: ...10.minutes).to_sql
+# => SELECT "steps".* FROM "steps" WHERE "steps"."duration" < 'PT10M'
+```
+
+If you cannot use a [hash condition](https://api.rubyonrails.org/v7.0.3/classes/ActiveRecord/QueryMethods.html#method-i-where-label-hash), you'll need to cast `10.minutes` to [iso8601](https://api.rubyonrails.org/v7.0.3/classes/ActiveSupport/Duration.html#method-i-iso8601) so that it will be compatible with the [PostgreSQL interval output](https://www.postgresql.org/docs/14/datatype-datetime.html#DATATYPE-INTERVAL-OUTPUT).
+
+```ruby
+Step.where("duration >= ?", 10.minutes.iso8601)
+# => [#<Step>, #<Step>]
+```
+
+If you call [to_sql](https://api.rubyonrails.org/v7.0.3/classes/ActiveRecord/Relation.html#method-i-to_sql) you can see that the comparison is made against `PT10M` since this is what PostgreSQL expects.
+
+```ruby
+Step.where("duration >= ?", 10.minutes.iso8601).to_sql
+# => SELECT "steps".* FROM "steps" WHERE (duration >= 'PT10M')
+
+10.minutes.iso8601
+# => "PT10M"
+```
+
+## Query for records by duration through an association
+
+Let’s turn up the heat by querying for **recipes** by their duration. This is more challenging because the **recipe** does not have a duration column. Not only that, but a **recipe** has many **steps**, not just one, and each **step** could have a duration.
+
+```ruby
+class Recipe < ApplicationRecord
+  has_many :steps
+
+  def self.with_duration_less_than, -> (duration){
+    joins(:steps)
+      .group(:id)
+      .having("SUM(steps.duration) <= ?", duration.iso8601)
+  }
+end
+
+Recipe.with_duration_less_than(60.minutes)
+# => [#<Recipe>, #<Recipe>]
+```
+
+The use of [joins](https://api.rubyonrails.org/v7.0.3/classes/ActiveRecord/QueryMethods.html#method-i-joins) allows access to the associated **steps** table, which in turn allows access to the **duration** column. From there, we can call [having](https://api.rubyonrails.org/v7.0.3/classes/ActiveRecord/QueryMethods.html#method-i-having) to filter out rows that do not meet the specified criteria.
+
+## Grouping records by duration
+
+Now for the pièce de résistance: Let's group **recipes** by their duration. By using a combination of [group](https://api.rubyonrails.org/v7.0.3/classes/ActiveRecord/QueryMethods.html#method-i-group) and [sum](https://api.rubyonrails.org/v7.0.3/classes/ActiveRecord/Calculations.html#method-i-sum) while leveraging [order](https://api.rubyonrails.org/v7.0.3/classes/ActiveRecord/QueryMethods.html#method-i-order) we can group **recipes** by their duration sorted from quickest to longest.
+
+```ruby
+class Recipe < ApplicationRecord
+  has_many :steps
+
+  def self.by_duration
+    joins(:steps)
+      .group(:name)
+      .order("SUM(steps.duration) ASC")
+      .sum(:duration)
+  end
+end
+
+Recipe.by_duration
+# => {"Recipe Two"=>5 minutes, "Recipe One"=>25 minutes}
+```
+
+## Hungry for more?
+
+Check out [our cookbook](https://github.com/thoughtbot/active-record-recipes) for more active record recipes!

--- a/_posts/2022-09-29-detect-anomalies-in-user-behavior-using-rails-and-postgresql.md
+++ b/_posts/2022-09-29-detect-anomalies-in-user-behavior-using-rails-and-postgresql.md
@@ -9,3 +9,174 @@ categories: ["Ruby on Rails"]
 tags: ["PostgreSQL"]
 canonical_url: https://thoughtbot.com/blog/detect-anomalies-in-user-behavior-using-rails-and-postgresql
 ---
+
+Let’s focus on a metric that nearly all applications should be monitoring: The
+number of sign-ups per day. Wouldn’t it be nice to know if all of a sudden that
+number dropped significantly?
+
+The first thing we’ll need to do is to group users by the date they signed up,
+or in other words, group users by the date they were _created._
+
+```ruby
+ActiveRecord::Base.connection.exec_query(
+  <<-SQL
+    SELECT COUNT(*) AS total_sign_ups, created_at::date as date
+    FROM users
+    GROUP BY created_at::date
+    ORDER BY created_at::date DESC
+  SQL
+).to_a
+# => [{"total_sign_ups"=>99, "date"=>"2022-07-15"}, ...]
+```
+
+<aside class="info">
+💡 You’ll note that we need to <a href="https://www.postgresql.org/docs/14/sql-expressions.html#SQL-SYNTAX-TYPE-CASTS">type cast</a> the <strong>created_at</strong> column from a <strong>datetime</strong> to a <strong>date</strong>. Otherwise, users will be grouped by the exact second they were created.
+</aside>
+
+Now that we know how to group users by the date they signed up, we can figure
+out how many users sign up per day on average.
+
+```ruby
+ActiveRecord::Base.connection.exec_query(
+  <<-SQL
+    SELECT
+      AVG(users.total_sign_ups) AS sign_ups_per_day_on_average
+    FROM(
+      SELECT COUNT(*) AS total_sign_ups FROM users
+      GROUP BY created_at::date
+    )
+    AS users LIMIT 1
+  SQL
+).to_a
+# => [{"sign_ups_per_day_on_average"=>100}]
+```
+
+Now that we have our baseline, we can detect anomalies and be alerted when they
+occur.
+
+```ruby
+sign_ups_per_day_on_average = ActiveRecord::Base.connection.exec_query(
+  <<-SQL
+    SELECT
+      AVG(users.total_sign_ups) AS sign_ups_per_day_on_average
+    FROM(
+      SELECT COUNT(*) AS total_sign_ups FROM users
+      GROUP BY created_at::date
+    ) AS users LIMIT 1
+  SQL
+).to_a.first["sign_ups_per_day_on_average"]
+# => 100
+
+sign_ups_today = User.where("created_at::date = ?", Time.now).count
+# => 99
+
+# This can be run in a daily cron job
+if sign_ups_today < sign_ups_per_day_on_average
+  raise Anomaly::UserSignUpAnomaly
+end
+```
+
+However, this is not the most accurate way to detect anomalies. Although there
+were fewer sign-ups today than the average, we were only off by one. I'd hardly
+consider that an anomaly. What we need to consider is [standard
+deviation](https://en.wikipedia.org/wiki/Standard_deviation). Fortunately,
+PostgreSQL has us covered with its [Aggregate Functions for
+Statistics](https://www.postgresql.org/docs/14/functions-aggregate.html#FUNCTIONS-AGGREGATE-STATISTICS-TABLE).
+
+We can use the **STDDEV_SAMP** function to iterate through each row and return
+the standard deviation for sign-ups per day. Then, we can see if the number of
+sign-ups on a particular day is within 1 standard deviation of the average.
+
+```ruby
+result = ActiveRecord::Base.connection.exec_query(
+  <<-SQL
+    SELECT
+      AVG(total_sign_ups) AS sign_ups_per_day_on_average,
+      STDDEV_SAMP(total_sign_ups) AS standard_deviation
+    FROM(
+      SELECT COUNT(*) AS total_sign_ups FROM users
+      GROUP BY created_at::date
+    ) AS users LIMIT 1
+  SQL
+).to_a
+# => [{"sign_ups_per_day_on_average"=>100, "standard_deviation"=>5}]
+
+sign_ups_today = User.where("created_at::date = ?", Date.current).count
+# => 99
+
+lower_bounds = result.first["sign_ups_per_day_on_average"] - result.first["standard_deviation"]
+# => 95
+
+# This can be run in a daily cron job
+if sign_ups_today < lower_bounds
+  raise Anomaly::UserSignUpAnomaly
+end
+```
+
+Since the average number of sign-ups per day is 100, and the standard deviation
+is 5, that means in a [normal
+distribution](https://en.wikipedia.org/wiki/Normal_distribution) 68% of the time
+the number of sign-ups per day should be between 95 and 105 (1 standard
+deviation), and 95% of the time the number of sign-ups per day should be between
+90 and 100 (2 standard deviations).
+
+In our example, we'll assume that 1 standard deviation is enough to warrant an
+anomaly. Since we're only interested in a drop in sign-ups, we'll compare the
+number of sign-up today with 95.
+
+We don’t have to stop there, though. We can leverage the power of SQL to tell us
+if the result was an anomaly without needing to use Ruby. All we need is a [case
+statement](https://www.postgresql.org/docs/14/plpgsql-control-structures.html#id-1.8.8.8.6.6)
+and a sub-query.
+
+```ruby
+result = ActiveRecord::Base.connection.exec_query(
+  <<-SQL
+    SELECT
+      sign_ups_today,
+      CASE
+        WHEN sign_ups_today >= sign_ups_per_day_on_average - COALESCE(standard_deviation, 0) THEN false
+        ELSE true
+      END AS anomaly
+    FROM(
+      SELECT
+        AVG(total_sign_ups) AS sign_ups_per_day_on_average,
+        STDDEV_SAMP(total_sign_ups) AS standard_deviation,
+        (
+          SELECT COUNT(*) AS sign_ups_today
+          FROM users
+          WHERE created_at::date='#{Date.current}'
+        )
+      FROM(
+        SELECT COUNT(*) AS total_sign_ups FROM users
+        GROUP BY created_at::date
+      ) AS users
+    ) AS sign_ups_today LIMIT 1
+  SQL
+).to_a
+# => [{"sign_ups_today"=>99, "anomaly"=>false}]
+
+# This can be run in a daily cron job
+if result.first["anomaly"]
+  raise Anomaly::UserSignUpAnomaly
+end
+```
+
+The sub-query creates a table that returns the
+**sign_ups_per_day_on_average** and the **standard_deviation**. This allows
+us to use a **CASE** statement on the calculated result from those two columns
+when compared to **sign_ups_today** rather than doing the calculation in Ruby.
+
+Note that we use
+[COALESCE](https://www.postgresql.org/docs/14/functions-conditional.html#FUNCTIONS-COALESCE-NVL-IFNULL)
+to set the value of the **standard_deviation** to **0** if no value is returned.
+This can happen when there is not enough data to calculate the standard
+deviation. This fallback simply compares the number of signs up to the average
+number of sign-ups.
+
+This pattern doesn’t have to be limited to user sign-ups. It can be applied to
+any action on your system, such as the number of items purchased per day, or the
+number of comments posted per day. If you find that the data you need to query
+doesn’t exist in your system, consider [tracking those
+events](https://thoughtbot.com/blog/rails-server-side-analytics-from-scratch) in
+a custom database table.

--- a/_posts/2022-11-14-automate-manual-deployments-with-git-and-binstubs.md
+++ b/_posts/2022-11-14-automate-manual-deployments-with-git-and-binstubs.md
@@ -9,3 +9,217 @@ categories: ["Web Development"]
 tags: ["git"]
 canonical_url: https://thoughtbot.com/blog/automate-manual-deployments-with-git-and-binstubs
 ---
+
+I'm currently on a project that cannot use an automated continuous deployment
+strategy because of our QA process and because our hosting environment does not
+have an automated release feature. Our deployment process looks something like
+this:
+
+1. Merge a pull request into `main`.
+2. The `main` branch is deployed to our staging environment.
+3. Run QA against staging.
+
+Once QA is complete, we then have to manually push `main` to production. This
+usually includes several dozen commits, so I tend to compare the latest commit
+on production with what I am about to push.
+
+```sh
+$ git fetch origin
+$ git fetch production
+$ git log origin/main...procution/main --oneline
+```
+
+I'll double-check with the team that those commits are the ones we want to push,
+and then once confirmed, I'll go ahead and push to production.
+
+```sh
+$ git push production main
+```
+
+Not only is this inefficient, but it also prevents new team members from feeling
+empowered to deploy the application. This results in only the most tenured team
+members being able to deploy, which only exasperates the problem.
+
+Surely there's got to be a better way, right?
+
+## Use binstubs to automate repetitive tasks
+
+Our project is already making use of [GitHub Actions] which runs linters, runs
+tests and deploys to our staging environment if those two actions pass, so why
+not just replicate this locally with a similar script? Well, that's exactly what
+we did.
+
+[GitHub Actions]: https://docs.github.com/en/actions
+
+### Running CI locally
+
+I figured the first thing we could do to improve our deployment process would be
+to create a binstub to run CI for us. Not only could this be used as part of a
+larger deployment script, but it can also be run in isolation too.
+
+```sh
+#!/bin/sh
+
+set -e
+
+echo "[bin/ci] Running CI..."
+if ! bundle exec standardrb
+then
+  echo "[bin/ci] Linting failed. Exiting."
+  exit 1
+fi
+if ! bin/rspec --fail-fast --tag ~type:system
+then
+  echo "[bin/ci] Tests failed. Exiting."
+  exit 1
+fi
+if ! bin/rspec --fail-fast --tag type:system
+then
+  echo "[bin/ci] System tests failed. Exiting."
+  exit 1
+fi
+echo "[bin/ci] CI Passed."
+```
+
+The goal here is to be as efficient as possible by running the fastest code
+first, and making sure to exit immediately upon the first failure. There's no
+sense in running the slow system test suite if a unit test failed, or if there's
+a linting error. If one thing fails, the whole system fails.
+
+### Configuring our production remote
+
+In order to deploy to production, we'll need to make sure we have the remote
+configured correctly. Rather than make a team member read the Wiki and set up
+the remote manually, we can automate this process by running a few Git commands.
+
+```sh
+production=git@production.com/app.git
+
+if [ "$(git config remote.production.url)" != "$production" ]
+then
+  echo "[bin/deploy] Configuring production remote..."
+  git remote | grep production > /dev/null && git remote remove production
+  git remote add production $production
+fi
+```
+
+<aside class="info">
+  💡 The call to <code>> /dev/null</code> is a technique to silence output. This means that
+  we won't print the results from calling grep.
+</aside>
+
+The script checks if production is already configured. If it's not, we go ahead
+and have it configure for the person calling the script.
+
+### Showing what commits will be deployed
+
+Since we're normally deploying more than one commit, I like to see what those
+commits are just in case. This also gives me one last opportunity to confirm
+with my team what will be deployed.
+
+```sh
+base_branch=main
+current_branch="$(git branch --show-current)"
+git fetch origin
+git fetch production
+diff="$(git log origin/main...production/master)"
+
+if [ "$current_branch" != "$base_branch" ]
+then
+  echo "[bin/deploy] Please checkout main first."
+  exit 1
+fi
+
+if [ -n "$diff" ]
+then
+  echo "[bin/deploy] The following commits will be deployed:"
+  echo
+  echo "$diff"
+  echo
+  echo "[bin/deploy] Would you like to deploy these commits? [y/N]"
+  read -r response
+  response="${response:-n}"
+ if [ "$response" = y ]
+ then
+   bin/ci
+   git push production main
+ else
+   echo "[bin/deploy] Exiting."
+   exit 0
+ fi
+else
+  echo "[bin/deploy] There are no new commits to deploy."
+  exit 1
+fi
+```
+
+<aside class="info">
+  💡 We want to make sure we're on the <code>main</code> branch since we run the CI script
+before deploying. If we didn't do this, CI would be running against the
+currently checked out branch, and not <code>main</code>.
+</aside>
+
+You'll note that the team member executing this script needs to explicitly
+opt in to the deploy by hitting "y". Typing any other key will exit the script
+immediately.
+
+You'll also note that we run `bin/ci` before we actually deploy. This ensures
+that the code in `main` is in a deployable state.
+
+### Putting it all together
+
+Below is the final binstub for deploying to production. It takes several
+cumbersome, repetitive tasks and condenses them down into one command that
+anyone on the team (even folks who aren't developers) can run with confidence.
+
+```sh
+#!/bin/sh
+
+set -e
+
+base_branch=main
+current_branch="$(git branch --show-current)"
+production=git@production.com/app.git
+
+if [ "$current_branch" != "$base_branch" ]
+then
+  echo "[bin/deploy] Please checkout main first."
+  exit 1
+fi
+
+if [ "$(git config remote.production.url)" != "$production" ]
+then
+  echo "[bin/deploy] Configuring production remote..."
+  git remote | grep production > /dev/null && git remote remove production
+  git remote add production $production
+fi
+git fetch origin
+git fetch production
+diff="$(git log origin/main...production/master)"
+
+if [ -n "$diff" ]
+then
+  echo "[bin/deploy] The following commits will be deployed:"
+  echo
+  echo "$diff"
+  echo
+  echo "[bin/deploy] Would you like to deploy these commits? [y/N]"
+  read -r response
+  response="${response:-n}"
+ if [ "$response" = y ]
+ then
+   bin/ci
+   git push production main
+ else
+   echo "[bin/deploy] Exiting."
+   exit 0
+ fi
+else
+  echo "[bin/deploy] There are no new commits to deploy."
+  exit 1
+fi
+```
+
+What's great about this is that if our deployment process changes, we can
+capture that change in this script instead of a Wiki page which tends to be
+outdated and less effective.

--- a/_posts/2023-06-05-rails-has-one-limitations.md
+++ b/_posts/2023-06-05-rails-has-one-limitations.md
@@ -1,0 +1,184 @@
+---
+title: "Are you absolutely sure your `has_one` association really has one association?"
+exceprt: "Learn about an unexpected limitation with this API and how to combat it universally."
+categories: ["Ruby on Rails"]
+canonical_url: https://thoughtbot.com/blog/rails-has-one-limitations
+---
+
+The Rails [has_one][1] API has an unexpected limitation: It does not prevent
+**multiple** records from being associated to the parent record.
+
+Take this simple example straight from the [Rails Guides][1]. We have a
+`supplier` that `has_one` `account`. Seems simple enough, but let's take a
+closer look.
+
+```ruby
+class Supplier < ApplicationRecord
+  has_one :account
+end
+
+class Account < ApplicationRecord
+  belongs_to :supplier
+end
+
+class CreateAccounts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :accounts do |t|
+      t.string :name
+      t.belongs_to :supplier, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end
+```
+
+The API provides [association methods][2] including
+[create_other(attributes={})][3]. This allows us to create an `account`
+off of a `supplier`. If we do this more than once, we'll raise an error.
+
+```ruby
+supplier = Supplier.create!
+supplier.create_account(name: "first")
+
+Account.count
+# => 1
+
+supplier.create_account(name: "second")
+# => Failed to remove the existing associated account. The record failed to save after its foreign key was set to nil. (ActiveRecord::RecordNotSaved)
+```
+
+At first glance, you might think that the `ActiveRecord::RecordNotSaved`
+error means that our `has_one` association is working as expected, and that
+it prevented another `account` record from being created. Unfortunately, what's
+really happening is that we couldn't `nullify` the `supplier_id` on the existing
+`account`, but we were still able to create a new `account` that is associated
+with the `supplier`. This leaves us with an orphaned `account` record.
+
+```ruby
+Account.count # <- We still created another record ‼️
+# => 2
+
+Account.last.name
+# => "second"
+
+Account.last.supplier == supplier
+# => true
+
+supplier.account.name
+# => "first"
+```
+
+<aside class="info">
+Prior to Rails <code>7.0.5</code>, calling <code>create_other</code> multiple
+times would have resulted in additional records being created. Here's the <a
+href="https://github.com/rails/rails/pull/46386">pull request</a> that improved
+this behavior by ensuring only one record is ever created.
+</aside>
+
+As we can see, the `account` is associated with the `supplier`, but the
+`supplier` is still associated with the original `account`. Rails attempted to
+`nullify` the `supplier_id` on the first `account` in an effort to maintain the
+`has_one` relationship, but our database constraint prevented it from doing so.
+What we need to do is add an option to [delete the association][4].
+
+```ruby
+class Supplier < ApplicationRecord
+  has_one :account, dependent: :destroy
+end
+```
+
+Now Rails will know to delete the original `account` once the new `account` has
+been created.
+
+```ruby
+supplier = Supplier.create!
+supplier.create_account(name: "first")
+supplier.create_account(name: "second")
+
+Account.count
+# => 1
+
+supplier.account.name
+# => "second"
+```
+
+However, there's a subtle yet important limitation with our current
+implementation. We can still associate more than one `account` with the same
+`supplier` if we simply bypass the generated [association method][2]!
+
+```ruby
+supplier = Supplier.create!
+supplier.create_account(name: "first")
+
+Account.create(name: "second", supplier: supplier) # <- We can still create another record ‼️
+# => #<Account>
+
+supplier.account.name
+# => "second"
+```
+
+As you can see, there's nothing preventing us from creating another `account`
+record if we avoid using the `create_account` method. This is because we're not
+enforcing this constraint at the database. The [has_one][1] API simply provides
+some convenience methods, but it does not actually enforce the relationship.
+
+To fix this, we need to add a uniqueness constraint in the database. This is
+briefly mentioned in the [Guides][1].
+
+> Depending on the use case, you might also need to create a unique index and/or
+> a foreign key constraint on the supplier column for the accounts table. In
+> this case, the column definition might look like this:
+
+```diff
+class CreateAccounts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :accounts do |t|
+      t.string :name
+-     t.belongs_to :supplier, null: false, foreign_key: true
++     t.belongs_to :supplier, null: false, index: { unique: true }, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end
+```
+
+Now, if we try to create another association without the [association
+methods][2], we'll raise an error.
+
+```ruby
+supplier = Supplier.create!
+supplier.create_account(name: "first")
+
+Account.create(name: "second", supplier: supplier) # <- We can no longer create another record ✅
+# => ActiveRecord::RecordNotUnique
+
+Account.count
+# => 1
+```
+
+Additionally, we'll also raise an error if we use the [association methods][2].
+This is valuable since it's possible for an application to make this call in
+multiple places, such as background jobs or tasks.
+
+```ruby
+supplier = Supplier.create!
+supplier.create_account(name: "first")
+
+supplier.create_account(name: "second") # <- We can no longer create another record ✅
+# => ActiveRecord::RecordNotUnique
+
+Account.count
+# => 1
+```
+
+So, the next time you're thinking of implementing a `has_one` relationship,
+consider what we just reviewed. Rails itself does not guarantee a 1:1
+relationship. That responsibility is on you. Pushing that constraint into the
+database provides a safety net against this often overlooked pitfall.
+
+[1]: https://guides.rubyonrails.org/association_basics.html#the-has-one-association
+[2]: https://guides.rubyonrails.org/association_basics.html#has-one-association-reference
+[3]: https://api.rubyonrails.org/v7.0.5/classes/ActiveRecord/Associations/ClassMethods.html#module-ActiveRecord::Associations::ClassMethods-label-Auto-generated+methods
+[4]: https://api.rubyonrails.org/v7.0.5/classes/ActiveRecord/Associations/ClassMethods.html#module-ActiveRecord::Associations::ClassMethods-label-Deleting+from+associations


### PR DESCRIPTION
Although we redirect to the original post, it's helpful to add the
content so that the RSS feed has something to render.

Prior to this commit, the RSS data for the actual post was empty.
